### PR TITLE
feat: Include "Source Modified" information for Bulk Status

### DIFF
--- a/tools/bulk/page-status/index.html
+++ b/tools/bulk/page-status/index.html
@@ -46,6 +46,7 @@
         <div class="page-status-results">
           <div class="headers">
             <div>Path</div>
+            <div>Source Modified</div>
             <div>Previewed</div>
             <div>Published</div>
           </div>

--- a/tools/bulk/page-status/scripts.js
+++ b/tools/bulk/page-status/scripts.js
@@ -52,10 +52,16 @@ async function populateResults(url) {
   resources.forEach((resource) => {
     const {
       path,
+      sourceLastModified,
       previewLastModified,
       publishLastModified,
     } = resource;
-    results.append(div({ class: 'path' }, path), div(previewLastModified || ''), div(publishLastModified || ''));
+    results.append(
+      div({ class: 'path' }, path),
+      div(sourceLastModified || ''),
+      div(previewLastModified || ''),
+      div(publishLastModified || ''),
+    );
   });
   document.querySelector('.page-status-results .loading').setAttribute('aria-hidden', 'true');
   results.setAttribute('aria-hidden', 'false');
@@ -84,7 +90,7 @@ async function startJob(owner, repo, path) {
   }
 
   const opts = {
-    body: JSON.stringify({ paths: [path] }),
+    body: JSON.stringify({ paths: [path], select: ['edit', 'preview', 'live'] }),
     ...OPTIONS,
   };
   const resp = await fetch(`https://admin.hlx.page/status/${owner}/${repo}/main/*`, opts);

--- a/tools/bulk/page-status/styles.css
+++ b/tools/bulk/page-status/styles.css
@@ -30,7 +30,7 @@
     & .headers,
     & .results {
       display: grid;
-      grid-template-columns: 2fr 1fr 1fr;
+      grid-template-columns: 1.5fr 1fr 1fr 1fr;
       column-gap: 10px;
 
       & > div {
@@ -41,7 +41,7 @@
         overflow-x: scroll;
       }
 
-      & > div:nth-child(3n + 1) {
+      & > div:nth-child(4n + 1) {
         text-align: left;
         padding-left: 3px;
       }

--- a/tools/bulk/page-status/styles.css
+++ b/tools/bulk/page-status/styles.css
@@ -26,6 +26,9 @@
   }
 
   .page-status-results {
+    & .headers > div {
+      font-weight: var(--weight-bold);
+    }
 
     & .headers,
     & .results {
@@ -44,15 +47,12 @@
       & > div:nth-child(4n + 1) {
         text-align: left;
         padding-left: 3px;
+        text-wrap: auto;
       }
 
       &[aria-hidden='true'] {
         display: none;
       }
-    }
-
-    & .headers > div {
-      font-weight: var(--weight-bold);
     }
 
     & .loading {
@@ -68,7 +68,7 @@
 
       & i.symbol {
         --border-m: 7px;
-
+        
         width: 5em;
         height: 5em;
         color: var(--gray-200);


### PR DESCRIPTION
The Bulk Status API supports also retrieving the last modified date of the sharepoint resource.
This would be useful for customers to see when were the resources last modified vs. previewed, vs. published to see if there are newer changes.

Context: This is the result of a customer request, where they wanted to have a report with the following header:
| URL | Publish Status | Created Date | Modified Date | Published Date
|-- | -- | -- | -- | --|

Except for:
* `Created Date` which is not exposed
* `Publish Status` which is the same as having a Publish Date

The rest of the information, should be available through the tool after this PR.

Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/tools/bulk/page-status/index.html
- After: https://sourcemodified--helix-labs-website--adobe.aem.live/tools/bulk/page-status/index.html