### PR TITLE
Bulk status styling

### DIFF
--- a/tools/bulk/page-status/styles.css
+++ b/tools/bulk/page-status/styles.css
@@ -48,6 +48,7 @@
       & > div:nth-child(4n + 1) {
         text-align: left;
         text-wrap: auto;
+        white-space: normal;
       }
 
       &[aria-hidden='true'] {

--- a/tools/bulk/page-status/styles.css
+++ b/tools/bulk/page-status/styles.css
@@ -49,6 +49,7 @@
         text-align: left;
         text-wrap: auto;
         white-space: normal;
+        max-width: 350px;
       }
 
       &[aria-hidden='true'] {


### PR DESCRIPTION

Fix styling issue with longer paths for bulk status

Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/
- After: https://bulk-status-styling--helix-labs-website--adobe.aem.live/
