### PR TITLE
SITES-26634 [Importer] Labs UI: Allow population of the URLs field from a file

### DIFF
--- a/tools/import/import.css
+++ b/tools/import/import.css
@@ -79,6 +79,10 @@
   border-top: var(--border-m) solid var(--gray-300);
 }
 
+.import .form .dragover {
+  border: var(--border-l) solid var(--green-500);
+}
+
 .import .heading {
   display: flex;
   flex-direction: row;

--- a/tools/import/import.js
+++ b/tools/import/import.js
@@ -254,4 +254,35 @@ function addJobsList(jobs) {
       scriptName.textContent = `${file.name} (${fileSizeInKB} KB)`;
     }
   });
+
+  fields.urls.addEventListener('dragenter', (event) => {
+    event.preventDefault();
+    event.target.classList.add('dragover');
+  });
+  fields.urls.addEventListener('dragleave', (event) => {
+    event.preventDefault();
+    event.target.classList.remove('dragover');
+  });
+
+  fields.urls.addEventListener('drop', (event) => {
+    event.preventDefault();
+    event.target.classList.remove('dragover');
+    fields.urls.value = '';
+    if (event.dataTransfer.files) {
+      // Use DataTransferItemList interface to access the file first URL file.
+      [...event.dataTransfer.files].forEach((droppedFile) => {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const lines = e.target.result.split('\n')
+            .map((line) => line.trim())
+            .filter((line) => line.startsWith('http'));
+          // If there are URLs in the file, add them to the textarea if it is still empty.
+          if (lines.length > 0 && fields.urls.value.length === 0) {
+            fields.urls.value = lines.join('\n');
+          }
+        };
+        reader.readAsText(droppedFile);
+      });
+    }
+  });
 })();

--- a/tools/import/import.js
+++ b/tools/import/import.js
@@ -271,17 +271,20 @@ function addJobsList(jobs) {
     if (event.dataTransfer.files) {
       // Use DataTransferItemList interface to access the file first URL file.
       [...event.dataTransfer.files].forEach((droppedFile) => {
-        const reader = new FileReader();
-        reader.onload = (e) => {
-          const lines = e.target.result.split('\n')
-            .map((line) => line.trim())
-            .filter((line) => line.startsWith('http'));
-          // If there are URLs in the file, add them to the textarea if it is still empty.
-          if (lines.length > 0 && fields.urls.value.length === 0) {
-            fields.urls.value = lines.join('\n');
-          }
-        };
-        reader.readAsText(droppedFile);
+        // Only process the next file if no URLs have been added to the textarea.
+        if (fields.urls.value.length === 0) {
+          const reader = new FileReader();
+          reader.onload = (e) => {
+            const lines = e.target.result.split('\n')
+              .map((line) => line.trim())
+              .filter((line) => line.startsWith('http'));
+            // If there are URLs in the file, add them to the textarea if it is still empty.
+            if (lines.length > 0) {
+              fields.urls.value = lines.join('\n');
+            }
+          };
+          reader.readAsText(droppedFile);
+        }
       });
     }
   });

--- a/tools/import/index.html
+++ b/tools/import/index.html
@@ -27,11 +27,13 @@
                     <input id="apiKey-input" type="password" autocomplete="apiKey" required/>
                 </div>
                 <div class="field" id="url-drop-zone">
-                    <div style="display: flex; justify-content: space-between;">
-                        <label for="url-input">URLs</label>
-                        <span style="{align-content: flex-end; font-size: 6px}"><em>Drop text file to populate.</em></span>
-                    </div>
+                    <label for="url-input">URLs</label>
                     <textarea id="url-input" required placeholder="One URL per line"></textarea>
+                    <div class="field-help-text">
+                        <p>
+                            You may drop a text file which has one URL per line into this field to populate it.
+                        </p>
+                    </div>
                 </div>
                 <div class="field">
                     <label for="import-script">Import Script</label>

--- a/tools/import/index.html
+++ b/tools/import/index.html
@@ -26,8 +26,11 @@
                     <label for="apiKey-input">API Key</label>
                     <input id="apiKey-input" type="password" autocomplete="apiKey" required/>
                 </div>
-                <div class="field">
-                    <label for="url-input">URLs</label>
+                <div class="field" id="url-drop-zone">
+                    <div style="display: flex; justify-content: space-between;">
+                        <label for="url-input">URLs</label>
+                        <span style="{align-content: flex-end; font-size: 6px}"><em>Drop text file to populate.</em></span>
+                    </div>
                     <textarea id="url-input" required placeholder="One URL per line"></textarea>
                 </div>
                 <div class="field">

--- a/tools/import/index.html
+++ b/tools/import/index.html
@@ -31,7 +31,7 @@
                     <textarea id="url-input" required placeholder="One URL per line"></textarea>
                     <div class="field-help-text">
                         <p>
-                            You may drop a text file which has one URL per line into this field to populate it.
+                            A text file with one URL per line may be dropped onto this field to populate it.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Fix [Jira SITES-26634](https://jira.corp.adobe.com/browse/SITES-26634)

The command line bulk importer takes a text file full of URLs.  Enable that same file to be dropped into the UI, instead of having to copy and paste.  Only lines with URLs starting with `http` will be added.
On multiple file drop, only the first file with valid URLs will be used.

Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/tools/import/index.html
- After: https://sites-26634-urls-file--helix-labs-website--adobe.aem.live/tools/import/index.html
