### PR TITLE
(Chore) blocking redirects stops valid requests

### DIFF
--- a/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
+++ b/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
@@ -129,6 +129,9 @@ class AbstractEDSSitemapCrawler extends AbstractCrawler {
     try {
     // this counts on url.plain, which wont work for non eds sites.
       const rawHtml = await CrawlerUtil.fetchPageHtml(url.plain);
+      if (!rawHtml) {
+        return [];
+      }
       // everything from here to the end needs to be synchronous or the document will load.
       // TODO: innerhtml here isn't great. Because it's using plain.html it's somewhat manageable.
       html.innerHTML = rawHtml;

--- a/tools/image-audit/crawler/util/crawlerutil.js
+++ b/tools/image-audit/crawler/util/crawlerutil.js
@@ -52,10 +52,13 @@ class CrawlerUtil {
   }
 
   static async fetchPageHtml(url) {
-    const req = await fetch(url, { redirect: 'manual' });
+    const req = await fetch(url);
     if (req.ok) {
       return req.text();
     }
+    // eslint-disable-next-line no-console
+    console.warn(`Failed to fetch page at ${url} with http status ${req.status}`);
+
     return null;
   }
 }


### PR DESCRIPTION
I also tried following the redirect manually, but the browser blocks this with a req.status of 0. We're doing some pre-flight checks which I believe makes the manual unnecessary here.

Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/tools/image-audit/index.html
- After: https://crawler-redirect-bug--helix-labs-website--adobe.aem.live/tools/image-audit/index.html
