### PR TITLE
renaming the titles for template, block cards with block count api end point integrated

### DIFF
--- a/blocks/data-element/data-element.js
+++ b/blocks/data-element/data-element.js
@@ -137,7 +137,7 @@ const metrics = {
           copyButton.addEventListener('click', () => {
             const urls = [];
             sitemapData.sitemaps.forEach((sitemap) => {
-              sitemap.forEach((p) => urls.push(p.page));
+              sitemap.forEach((p) => urls.push(p.page.startsWith("/") ? sessionStorage.getItem('powerScoreUrl').concat(p.page) : p.page));
             });
             navigator.clipboard.writeText(urls.join('\n'));
             copyButton.setAttribute('disabled', true);
@@ -157,7 +157,7 @@ const metrics = {
   },
   layouts: {
     depends: [DATA_TYPES.TEMPLATES],
-    label: 'Layouts',
+    label: 'Layouts (approx.)',
     render: async (blockInner, [templateData], { isCalculator, initialRender }) => {
       const dataCopy = templateData;
       const templateCount = dataCopy.templates.numTemplates;
@@ -174,7 +174,7 @@ const metrics = {
             updateUrlHash(input.dataset.paramName, input.value);
           });
         } else {
-          blockInner.innerHTML = `<p><span data-name="numTemplates">${templateCount}</span>(-ish?)</p>`;
+          blockInner.innerHTML = `<p><span data-name="numTemplates">${templateCount}</span></p>`;
         }
         blockInner.classList.remove('loading');
       }
@@ -188,7 +188,7 @@ const metrics = {
   },
   blocks: {
     depends: [DATA_TYPES.BLOCKS],
-    label: 'Avg Blocks / Layout',
+    label: 'Blocks (approx.)',
     render: async (blockInner, [blockData], { isCalculator, initialRender }) => {
       const dataCopy = blockData;
       const { blockCount } = dataCopy;
@@ -206,14 +206,14 @@ const metrics = {
             updateUrlHash(input.dataset.paramName, input.value);
           });
         } else {
-          blockInner.innerHTML = '<p><span data-name="blockCount"></span>(-ish?)</p>';
+          blockInner.innerHTML = '<p><span data-name="blockCount"></span></p>';
         }
         blockInner.classList.remove('loading');
       }
       const dataEl = blockInner.querySelector('[data-name="blockCount"]');
       if (!isCalculator) {
         dataEl.textContent = roundedBlockCount;
-      } else {
+      } else { 
         dataEl.value = roundedBlockCount;
       }
     },

--- a/blocks/data-element/data-element.js
+++ b/blocks/data-element/data-element.js
@@ -137,7 +137,7 @@ const metrics = {
           copyButton.addEventListener('click', () => {
             const urls = [];
             sitemapData.sitemaps.forEach((sitemap) => {
-              sitemap.forEach((p) => urls.push(p.page.startsWith("/") ? sessionStorage.getItem('powerScoreUrl').concat(p.page) : p.page));
+              sitemap.forEach((p) => urls.push(p.page.startsWith('/') ? sessionStorage.getItem('powerScoreUrl').concat(p.page) : p.page));
             });
             navigator.clipboard.writeText(urls.join('\n'));
             copyButton.setAttribute('disabled', true);
@@ -213,7 +213,7 @@ const metrics = {
       const dataEl = blockInner.querySelector('[data-name="blockCount"]');
       if (!isCalculator) {
         dataEl.textContent = roundedBlockCount;
-      } else { 
+      } else {
         dataEl.value = roundedBlockCount;
       }
     },

--- a/blocks/results/results-data.js
+++ b/blocks/results/results-data.js
@@ -335,12 +335,16 @@ const sampleUrls = (sitemapData) => {
   const allUrls = [];
   sitemapData.sitemaps.forEach((sitemap) => {
     sitemap.forEach((p) => allUrls.push(
-      p.page.startsWith("/") ? sessionStorage.getItem('powerScoreUrl').concat(p.page) : p.page));
+      p.page.startsWith('/')
+        ? sessionStorage.getItem('powerScoreUrl').concat(p.page) : p.page,
+    ));
   });
 
   const topLevelUrls = allUrls.filter((u) => {
-    if(u.startsWith("/"))
+    if (u.startsWith('/')) {
+      // eslint-disable-next-line no-param-reassign
       u = sessionStorage.getItem('powerScoreUrl').concat(u);
+    }
     const url = new URL(u);
     const segments = url.pathname.split('/').filter((seg) => seg.trim() !== '');
     return segments.length < 2;

--- a/blocks/results/results-data.js
+++ b/blocks/results/results-data.js
@@ -334,10 +334,13 @@ const sampleUrls = (sitemapData) => {
   const sampledUrls = [];
   const allUrls = [];
   sitemapData.sitemaps.forEach((sitemap) => {
-    sitemap.forEach((p) => allUrls.push(p.page));
+    sitemap.forEach((p) => allUrls.push(
+      p.page.startsWith("/") ? sessionStorage.getItem('powerScoreUrl').concat(p.page) : p.page));
   });
 
   const topLevelUrls = allUrls.filter((u) => {
+    if(u.startsWith("/"))
+      u = sessionStorage.getItem('powerScoreUrl').concat(u);
     const url = new URL(u);
     const segments = url.pathname.split('/').filter((seg) => seg.trim() !== '');
     return segments.length < 2;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/tools/powerscore
- After: https://powerscore-blockcount--helix-labs-website--adobe.aem.live/tools/powerscore

Visual Difference 
Live 
<img width="641" alt="image" src="https://github.com/user-attachments/assets/c5b5b461-9586-4af3-bcec-ae1ac027e131">

Modified to 
<img width="564" alt="image" src="https://github.com/user-attachments/assets/495e943c-c58f-431b-be25-516944e6be7a">

Note - Replacing ( -ish ) with ( approx.) in the card header . Also as the blocks are total number of blocks , removing the average from Block count. 

 