### PR TITLE
chore(bugs) Fixing reclustering error and reclustering identity error 

### DIFF
--- a/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
+++ b/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
@@ -56,30 +56,41 @@ class AbstractEDSSitemapCrawler extends AbstractCrawler {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  #getEDSOptimizedImageUrl(src, origin, defaultWidth) {
+  #getEDSOptimizedImageUrl(src, origin, width) {
     const originalUrl = new URL(src, origin);
+    if (!CrawlerUtil.isUrlValid(originalUrl)) {
+      return null;
+    }
     const aemSite = AEM_EDS_HOSTS.find((h) => originalUrl.host.endsWith(h));
     if (!aemSite) {
       return src;
     }
 
+    originalUrl.searchParams.set('width', width);
+    originalUrl.searchParams.set('format', 'webply');
+    originalUrl.searchParams.set('optimize', 'medium');
+
+    return originalUrl.href;
+
+    /*
     // Use the width from the query parameter if available, otherwise use the provided defaultWidth
     const width = originalUrl.searchParams.has('width')
       ? originalUrl.searchParams.get('width')
       : defaultWidth;
-
     const pictureElement = createOptimizedPicture(
       originalUrl,
       'Optimized Image',
-      false,
+      true,
       [
         { media: `(min-width: ${width}px)`, width: `${width}` },
         { width: `${width}` },
       ],
     );
-
     // Extract the URL of the best-matched <source> for this device from pictureElement
-    return `.${pictureElement.querySelector('source').getAttribute('srcset')}`;
+    const rv = `.${pictureElement.querySelector('source').getAttribute('srcset')}`;
+    pictureElement.outerHTML = '';
+    return rv;
+    */
   }
 
   stop() {

--- a/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
+++ b/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
@@ -70,26 +70,6 @@ class AbstractEDSSitemapCrawler extends AbstractCrawler {
     originalUrl.searchParams.set('optimize', 'medium');
 
     return originalUrl.href;
-
-    /*
-    // Use the width from the query parameter if available, otherwise use the provided defaultWidth
-    const width = originalUrl.searchParams.has('width')
-      ? originalUrl.searchParams.get('width')
-      : defaultWidth;
-    const pictureElement = createOptimizedPicture(
-      originalUrl,
-      'Optimized Image',
-      true,
-      [
-        { media: `(min-width: ${width}px)`, width: `${width}` },
-        { width: `${width}` },
-      ],
-    );
-    // Extract the URL of the best-matched <source> for this device from pictureElement
-    const rv = `.${pictureElement.querySelector('source').getAttribute('srcset')}`;
-    pictureElement.outerHTML = '';
-    return rv;
-    */
   }
 
   stop() {

--- a/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
+++ b/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
@@ -1,5 +1,4 @@
 // eslint-disable-next-line import/no-relative-packages
-import { createOptimizedPicture } from '../../../../scripts/aem.js';
 import { AEM_EDS_HOSTS } from '../../identity/imageidentity/urlidentity.js';
 import CrawlerUtil from '../util/crawlerutil.js';
 import ImageAudutUtil from '../../util/imageauditutil.js';

--- a/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
+++ b/tools/image-audit/crawler/eds/abstractedssitemapcrawler.js
@@ -146,7 +146,7 @@ class AbstractEDSSitemapCrawler extends AbstractCrawler {
       html.innerHTML = rawHtml;
       if (html) {
         const seenMap = new Map();
-        const images = html.querySelectorAll('img[src]');
+        const images = html.querySelectorAll('img[crawledsrc]');
         const imgData = [...images].map((img) => {
           let width = img.getAttribute('width') || img.naturalWidth;
           let height = img.getAttribute('height') || img.naturalHeight;
@@ -172,7 +172,7 @@ class AbstractEDSSitemapCrawler extends AbstractCrawler {
           }
 
           const { origin } = new URL(url.href);
-          const src = img.getAttribute('src').split('?')[0];
+          const src = img?.getAttribute('crawledsrc')?.split('?')[0];
           const originalUrl = new URL(src, origin);
 
           if (!CrawlerUtil.isUrlValid(originalUrl)) {

--- a/tools/image-audit/crawler/util/crawlerutil.js
+++ b/tools/image-audit/crawler/util/crawlerutil.js
@@ -23,6 +23,8 @@ class CrawlerUtil {
       } catch (error) {
         return false;
       }
+    } else if (typeof url?.href === 'string' && typeof url?.plain === 'string') {
+      return this.isUrlValid(url.href) && this.isUrlValid(url.plain);
     } else if (typeof url?.href === 'string') {
       return this.isUrlValid(url.href);
     } else if (typeof url?.origin === 'string' && typeof url?.src === 'string') {

--- a/tools/image-audit/crawler/util/crawlerutil.js
+++ b/tools/image-audit/crawler/util/crawlerutil.js
@@ -10,37 +10,39 @@ class CrawlerUtil {
   */
   static isUrlValid(url) {
     if (!url) return false;
-    let protocol = '';
     if (url instanceof URL) {
-      if (url.hostname === 'localhost') {
+      if (url.hostname === 'localhost' || url.hostname === '') {
         return false;
       }
-      protocol = url.protocol.replace(':', '').toLowerCase();
-    } else if (typeof url === 'string') {
+      const protocol = url.protocol.replace(':', '').toLowerCase();
+      return this.#permittedProtocols.includes(protocol);
+    }
+    if (typeof url === 'string') {
       try {
         const newUrl = new URL(url);
         return this.isUrlValid(newUrl);
       } catch (error) {
         return false;
       }
-    } else if (typeof url?.href === 'string' && typeof url?.plain === 'string') {
+    }
+    if (typeof url?.href === 'string' && typeof url?.plain === 'string') {
       return this.isUrlValid(url.href) && this.isUrlValid(url.plain);
-    } else if (typeof url?.href === 'string') {
+    }
+    if (typeof url?.href === 'string') {
       return this.isUrlValid(url.href);
-    } else if (typeof url?.origin === 'string' && typeof url?.src === 'string') {
+    }
+    if (typeof url?.origin === 'string' && typeof url?.src === 'string') {
       try {
         const newUrl = new URL(url.src, url.origin);
         return this.isUrlValid(newUrl);
       } catch (error) {
         return false;
       }
-    } else if (typeof url?.origin === 'string') {
-      return this.isUrlValid(url.origin);
-    } else {
-      return false;
     }
-
-    return this.#permittedProtocols.includes(protocol);
+    if (typeof url?.origin === 'string') {
+      return this.isUrlValid(url.origin);
+    }
+    return false;
   }
 
   /**

--- a/tools/image-audit/identity/clustermanager.js
+++ b/tools/image-audit/identity/clustermanager.js
@@ -61,8 +61,10 @@ class ClusterManager {
   reclusterComplete(persistedCluster, consumedCluster) {
     // This maintains a reference from the old cluster to the new one
     // so that any async operations automatically pick up this change.
+    // console.debug(`Setting ${consumedCluster.id} to ${persistedCluster.id}`);
     this.#clusterMap.set(consumedCluster.id, persistedCluster);
     consumedCluster.clusterIdsThisClusterReplaces.forEach((clusterId) => {
+      // console.debug(`Setting ${clusterId} to ${persistedCluster.id}`);
       this.#clusterMap.set(clusterId, persistedCluster);
     });
   }

--- a/tools/image-audit/identity/identitycluster.js
+++ b/tools/image-audit/identity/identitycluster.js
@@ -94,9 +94,16 @@ class IdentityCluster {
     if (this.#replacedBy) {
       throw new Error(`Cluster ${this.id} was replaced by ${this.#replacedBy.id}`);
     }
-
-    this.#insertIdentity(identity);
-    this.#clusterManager.identityAdded(identity, this);
+    if (identity.singleton && this.getSingletonOf(identity.type)) {
+      // This should only happen because the cluster we're referencing has had another
+      // cluster merged into it, and async operations are still operating on the current cluster
+      // eslint-disable-next-line no-console
+      console.debug(`Adding singleton identity ${identity.type} to cluster ${this.id} which already has this identity type. Merging.`);
+      this.getSingletonOf(identity.type)?.mergeOther(identity);
+    } else {
+      this.#insertIdentity(identity);
+      this.#clusterManager.identityAdded(identity, this);
+    }
   }
 
   #insertIdentity(identity) {

--- a/tools/image-audit/identity/identitycluster.js
+++ b/tools/image-audit/identity/identitycluster.js
@@ -98,7 +98,6 @@ class IdentityCluster {
       // This should only happen because the cluster we're referencing has had another
       // cluster merged into it, and async operations are still operating on the current cluster
       // eslint-disable-next-line no-console
-      console.debug(`Adding singleton identity ${identity.type} to cluster ${this.id} which already has this identity type. Merging.`);
       this.getSingletonOf(identity.type)?.mergeOther(identity);
     } else {
       this.#insertIdentity(identity);

--- a/tools/image-audit/identity/imageidentity/coloridentity.js
+++ b/tools/image-audit/identity/imageidentity/coloridentity.js
@@ -139,8 +139,9 @@ class ColorIdentity extends AbstractIdentity {
     const { originatingClusterId, clusterManager, href } = identityValues;
     const colorIdentity = new ColorIdentity(identityState);
 
+    const sizeId = await SizeIdentity.getSizeId(href);
     const sizeIdentifier = clusterManager.get(originatingClusterId)
-      .get(await SizeIdentity.getSizeId(href));
+      .get(sizeId);
     if (sizeIdentifier?.tooBigForWeb) {
       // don't bother with large images.
       colorIdentity.#topColors.add(ColorUtility.UNKNOWN_NAME);

--- a/tools/image-audit/identity/imageidentity/perceptualidentity.js
+++ b/tools/image-audit/identity/imageidentity/perceptualidentity.js
@@ -75,8 +75,9 @@ class PerceptualIdentity extends AbstractIdentity {
       return; // it already has one, maybe due to a merge.
     }
 
+    const sizeId = await SizeIdentity.getSizeId(href);
     const sizeIdentifier = clusterManager.get(originatingClusterId)
-      .get(await SizeIdentity.getSizeId(href));
+      .get(sizeId);
     if (sizeIdentifier?.tooBigForWeb) {
       // don't bother with large images.
       return;

--- a/tools/image-audit/identity/imageidentity/textidentity.js
+++ b/tools/image-audit/identity/imageidentity/textidentity.js
@@ -38,8 +38,9 @@ class TextIdentity extends AbstractIdentity {
   static async identifyPostflight(identityValues, identityState) {
     const { originatingClusterId, clusterManager, href } = identityValues;
 
+    const sizeId = await SizeIdentity.getSizeId(href);
     const sizeIdentifier = clusterManager.get(originatingClusterId)
-      .get(await SizeIdentity.getSizeId(href));
+      .get(sizeId);
     const tooBigForWeb = sizeIdentifier?.tooBigForWeb;
 
     if (!identityState.promisePool) {

--- a/tools/image-audit/identity/imageidentity/textidentity.js
+++ b/tools/image-audit/identity/imageidentity/textidentity.js
@@ -36,7 +36,11 @@ class TextIdentity extends AbstractIdentity {
   }
 
   static async identifyPostflight(identityValues, identityState) {
-    const { originatingClusterId, clusterManager, href } = identityValues;
+    const {
+      originatingClusterId, clusterManager, href, width, height,
+    } = identityValues;
+
+    if (width <= 3 || height <= 3) return; // OCR doesn't work on these.
 
     const sizeId = await SizeIdentity.getSizeId(href);
     const sizeIdentifier = clusterManager.get(originatingClusterId)


### PR DESCRIPTION
Corrects an async problem in 3 of the identifiers, where they could be reclustered during a poorly placed await and then fail. 

Adjusting the URL calculation for the image to not create an actual image tag in the EDS crawler, causing logs in the errors loading images which weren't really being loaded.

Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/tools/image-audit/index.html
- After: https://color-and-localhost-bug--helix-labs-website--adobe.aem.live/tools/image-audit/index.html