### PR TITLE
fix: Don't send content-type header if body is empty

### DIFF
--- a/tools/admin-edit/admin-edit.js
+++ b/tools/admin-edit/admin-edit.js
@@ -180,7 +180,7 @@ bodyForm.addEventListener('submit', async (e) => {
   if (body.value) {
     headers['content-type'] = adminURL.value.endsWith('.yaml') ? 'text/yaml' : 'application/json';
   }
-  
+
   const resp = await fetch(adminURL.value, {
     method: reqMethod.value,
     body: body.value,

--- a/tools/admin-edit/admin-edit.js
+++ b/tools/admin-edit/admin-edit.js
@@ -176,12 +176,15 @@ function logResponse(cols) {
 bodyForm.addEventListener('submit', async (e) => {
   e.preventDefault();
   localStorage.setItem('admin-url', adminURL.value);
+  const headers = {};
+  if (body.value) {
+    headers['content-type'] = adminURL.value.endsWith('.yaml') ? 'text/yaml' : 'application/json';
+  }
+  
   const resp = await fetch(adminURL.value, {
     method: reqMethod.value,
     body: body.value,
-    headers: {
-      'content-type': adminURL.value.endsWith('.yaml') ? 'text/yaml' : 'application/json',
-    },
+    headers,
   });
   resp.text().then(() => {
     logResponse([resp.status, reqMethod.value, adminURL.value, resp.headers.get('x-error') || '']);


### PR DESCRIPTION
Setting `content-type: application/json` on a request without a body doesn't work, because empty string is not a valid json.

Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/tools/admin-edit/index.html
- After: https://fix-content-type--helix-labs-website--adobe.aem.live/tools/admin-edit/index.html
