### PR TITLE
fix: remove image audit postinstall hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@adobe/aem-boilerplate",
       "version": "1.3.0",
-      "hasInstallScript": true,
       "license": "Apache License 2.0",
       "dependencies": {
         "@adobe/rum-distiller": "1.11.1"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint blocks/**/*.css styles/*.css",
-    "lint": "npm run lint:js && npm run lint:css",
-    "postinstall": "(cd tools/image-audit && npm install)"
+    "lint": "npm run lint:js && npm run lint:css"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://fix-ci--helix-labs-website--adobe.aem.live/tools/image-audit/index.html
