### PR TITLE
fix: avoid sending too many requests at once

### DIFF
--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -330,6 +330,12 @@ async function init(doc) {
             });
           processingTasks.push(promise);
         }
+
+        // max 50 inflight at a time
+        if (processingTasks.length >= 50) {
+          await Promise.all(processingTasks);
+          processingTasks.splice(0, processingTasks.length);
+        }
       }
       resultsOfElement.textContent = searched;
       await Promise.all(processingTasks);


### PR DESCRIPTION
Fix #114 

Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/tools/site-query/index.html
- After: https://site-query-100-limit--helix-labs-website--adobe.aem.live/tools/site-query/index.html

limit to 50 at once, which seems more than enough

cc: @kptdobe 