### PR TITLE
chore: assume standard review URL for .aem.reviews

### DIFF
--- a/tools/snapshot-admin/palette.js
+++ b/tools/snapshot-admin/palette.js
@@ -31,7 +31,7 @@ const PAGE_STATUS_WRAPPER = document.getElementById('page-status-wrapper');
 async function init() {
   const state = referrer.hostname.includes('reviews') ? 'review' : 'page';
 
-  REVIEWS_LINK.href = CUSTOM_REVIEW_HOST ? `https://${CUSTOM_REVIEW_HOST}${PATHNAME}` : `https://${SNAPSHOT}--main--${REPO}--${OWNER}.aem.reviews${PATHNAME}`;
+  REVIEWS_LINK.href = (CUSTOM_REVIEW_HOST && !CUSTOM_REVIEW_HOST.endsWith('.aem.reviews')) ? `https://${CUSTOM_REVIEW_HOST}${PATHNAME}` : `https://${SNAPSHOT}--main--${REPO}--${OWNER}.aem.reviews${PATHNAME}`;
   ADMIN_LINK.href = `/tools/snapshot-admin/index.html?snapshot=https://main--${REPO}--${OWNER}.aem.page/.snapshots/${SNAPSHOT}/.manifest.json`;
 
   if (state === 'page') {


### PR DESCRIPTION
https://snapshot-reviewslink--helix-labs-website--adobe.aem.live/tools/snapshot-admin/palette.html?theme=dark&ref=main&repo=id&owner=davidnuescheler&host=independentdrinker.com&reviewHost=main--id--davidnuescheler.aem.reviews&referrer=https%3A%2F%2Fmain--id--davidnuescheler.aem.page%2F
