### PR TITLE
chore: allow create on 404

### DIFF
--- a/tools/snapshot-admin/index.html
+++ b/tools/snapshot-admin/index.html
@@ -49,7 +49,7 @@
       <form id="snapshot-edit-form">
         <fieldset>
           <textarea rows="20" id="snapshot-resources"></textarea>
-          <details>
+          <details id="snapshot-metadata">
             <summary>Snapshot metadata</summary>
             <label>
               Title

--- a/tools/snapshot-admin/index.html
+++ b/tools/snapshot-admin/index.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="/tools/snapshot-admin/snapshot-admin.css" />
 </head>
 
-<body class="snapshot-admin">
+<body class="snapshot-admin appear">
   <header></header>
   <main>
     <!-- TITLE -->

--- a/tools/snapshot-admin/snapshot-admin.js
+++ b/tools/snapshot-admin/snapshot-admin.js
@@ -17,6 +17,7 @@ const reviewApprove = document.getElementById('review-approve');
 const snapshotTitle = document.getElementById('snapshot-title');
 const snapshotDescription = document.getElementById('snapshot-description');
 const snapshotPassword = document.getElementById('snapshot-password');
+const snapshotMetadata = document.getElementById('snapshot-metadata');
 
 let manifest = {};
 let adminURL = '';
@@ -198,6 +199,15 @@ async function fetchSnapshotManifest(urlString) {
   const resp = await fetch(adminURL);
   if (resp.status === 200) {
     manifest = (await resp.json()).manifest;
+    displaySnapshot();
+  }
+  if (resp.status === 404) {
+    manifest = {
+      title: '',
+      description: '',
+      resources: [],
+    };
+    snapshotMetadata.open = true;
     displaySnapshot();
   }
   logResponse([resp.status, 'GET', adminURL, resp.headers.get('x-error') || '']);


### PR DESCRIPTION
allow creation of snapshot on a `404` response.

https://snapshot-create--helix-labs-website--adobe.aem.live/tools/snapshot-admin/index.html?snapshot=https%3A%2F%2Fmain--thinktanked--davidnuescheler.aem.page%2F.snapshots%2Fexample
