### PR TITLE
fix: Use enableJavascript

### DIFF
--- a/tools/import/index.html
+++ b/tools/import/index.html
@@ -55,8 +55,8 @@
                             <input id="timeout-input" type="number" value="10000" min="0" step="1000">
                         </div>
                         <div>
-                            <label for="enableJavaScript">Enable JavaScript</label>
-                            <input type="checkbox" id="enableJavaScript" name="enableJavaScript">
+                            <label for="enableJavascript">Enable JavaScript</label>
+                            <input type="checkbox" id="enableJavascript" name="enableJavascript">
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The capitalization is wrong for the `enableJavascript` option, which results in the user's choice not being respected:

<img width="660" height="468" alt="Screenshot 2025-07-31 at 12 04 30" src="https://github.com/user-attachments/assets/8fb8aeb2-fa6f-40b3-8680-1420095f50f6" />
