### PR TITLE
fix: support arrays for props in index admin tool

### DIFF
--- a/tools/index-admin/index-admin.css
+++ b/tools/index-admin/index-admin.css
@@ -222,7 +222,7 @@
 
       .properties-header {
         display: grid;
-        grid-template-columns: 1fr 1fr 1fr 1fr 60px;
+        grid-template-columns: 1fr 1fr 1fr 140px 1fr 60px;
         gap: var(--spacing-s);
         padding: var(--spacing-s) var(--spacing-m);
         background: var(--gray-100);
@@ -248,7 +248,7 @@
 
       .index-property {
         display: grid;
-        grid-template-columns: 1fr 1fr 1fr 1fr 60px;
+        grid-template-columns: 1fr 1fr 1fr 140px 1fr 60px;
         gap: var(--spacing-s);
         padding: var(--spacing-s) var(--spacing-m);
         border-bottom: 1px solid var(--gray-200);

--- a/tools/index-admin/index-admin.js
+++ b/tools/index-admin/index-admin.js
@@ -59,26 +59,31 @@ function displayIndexDetails(indexName, indexDef, newIndex = false) {
     const nameField = property.querySelector('#index-property-name');
     const selectField = property.querySelector('#index-property-select');
     const selectFirstField = property.querySelector('#index-property-select-first');
+    const valueTypeField = property.querySelector('#index-property-value-type');
     const valueField = property.querySelector('#index-property-value');
 
     nameField.id = `index-property-name-${idSuffix}`;
     selectField.id = `index-property-select-${idSuffix}`;
     selectFirstField.id = `index-property-select-first-${idSuffix}`;
+    valueTypeField.id = `index-property-value-type-${idSuffix}`;
     valueField.id = `index-property-value-${idSuffix}`;
 
     nameField.value = propName;
     selectField.value = propInfo.select || '';
     selectFirstField.value = propInfo.selectFirst || '';
-    valueField.value = propInfo.value;
+    valueTypeField.value = propInfo.value !== undefined ? 'value' : 'values';
+    valueField.value = propInfo.value ?? propInfo.values?.join?.('\n') ?? propInfo.values ?? '';
 
     const nameFieldLabel = property.querySelector('label[for="index-property-name"]');
     const selectFieldLabel = property.querySelector('label[for="index-property-select"]');
     const selectFirstFieldLabel = property.querySelector('label[for="index-property-select-first"]');
+    const valueTypeFieldLabel = property.querySelector('label[for="index-property-value-type"]');
     const valueFieldLabel = property.querySelector('label[for="index-property-value"]');
 
     nameFieldLabel.htmlFor = `index-property-name-${idSuffix}`;
     selectFieldLabel.htmlFor = `index-property-select-${idSuffix}`;
     selectFirstFieldLabel.htmlFor = `index-property-select-first-${idSuffix}`;
+    valueTypeFieldLabel.htmlFor = `index-property-value-type-${idSuffix}`;
     valueFieldLabel.htmlFor = `index-property-value-${idSuffix}`;
 
     property.querySelector('.remove-property-btn').addEventListener('click', () => {
@@ -99,21 +104,25 @@ function displayIndexDetails(indexName, indexDef, newIndex = false) {
     const nameField = property.querySelector('#index-property-name');
     const selectField = property.querySelector('#index-property-select');
     const selectFirstField = property.querySelector('#index-property-select-first');
+    const valueTypeField = property.querySelector('#index-property-value-type');
     const valueField = property.querySelector('#index-property-value');
 
     nameField.id = `index-property-name-${idSuffix}`;
     selectField.id = `index-property-select-${idSuffix}`;
     selectFirstField.id = `index-property-select-first-${idSuffix}`;
+    valueTypeField.id = `index-property-value-type-${idSuffix}`;
     valueField.id = `index-property-value-${idSuffix}`;
 
     const nameFieldLabel = property.querySelector('label[for="index-property-name"]');
     const selectFieldLabel = property.querySelector('label[for="index-property-select"]');
     const selectFirstFieldLabel = property.querySelector('label[for="index-property-select-first"]');
+    const valueTypeFieldLabel = property.querySelector('label[for="index-property-value-type"]');
     const valueFieldLabel = property.querySelector('label[for="index-property-value"]');
 
     nameFieldLabel.htmlFor = `index-property-name-${idSuffix}`;
     selectFieldLabel.htmlFor = `index-property-select-${idSuffix}`;
     selectFirstFieldLabel.htmlFor = `index-property-select-first-${idSuffix}`;
+    valueTypeFieldLabel.htmlFor = `index-property-value-type-${idSuffix}`;
     valueFieldLabel.htmlFor = `index-property-value-${idSuffix}`;
 
     property.querySelector('.remove-property-btn').addEventListener('click', () => {
@@ -132,9 +141,16 @@ function displayIndexDetails(indexName, indexDef, newIndex = false) {
       const name = property.querySelector(`#index-property-name-${idSuffix}`).value.trim();
       const select = property.querySelector(`#index-property-select-${idSuffix}`).value.trim();
       const selectFirst = property.querySelector(`#index-property-select-first-${idSuffix}`).value.trim();
-      const value = property.querySelector(`#index-property-value-${idSuffix}`).value.trim();
+      const valueType = property.querySelector(`#index-property-value-type-${idSuffix}`).value;
+      const valueInput = property.querySelector(`#index-property-value-${idSuffix}`).value.trim();
 
-      properties[name] = { value };
+      if (valueType === 'values') {
+        const valueLines = valueInput.split('\n').map((line) => line.trim()).filter((line) => line);
+        properties[name] = { values: valueLines.length > 0 ? valueLines : [valueInput] };
+      } else {
+        properties[name] = { value: valueInput };
+      }
+
       if (select) {
         properties[name].select = select;
       }

--- a/tools/index-admin/index.html
+++ b/tools/index-admin/index.html
@@ -116,7 +116,8 @@
                   <div class="header-cell">Name</div>
                   <div class="header-cell">Select</div>
                   <div class="header-cell">Select First</div>
-                  <div class="header-cell">Value</div>
+                  <div class="header-cell">Type</div>
+                  <div class="header-cell">Value(s)</div>
                   <div class="header-cell"></div>
                 </div>
               </div>
@@ -149,7 +150,14 @@
         <input type="text" id="index-property-select-first" name="index-property-select-first" />
       </div>
       <div class="form-field">
-        <label for="index-property-value">Property Value</label>
+        <label for="index-property-value-type">Type</label>
+        <select id="index-property-value-type" name="index-property-value-type">
+          <option value="value">Single</option>
+          <option value="values">Multiple</option>
+        </select>
+      </div>
+      <div class="form-field">
+        <label for="index-property-value">Property Value/Values</label>
         <input type="text" id="index-property-value" name="index-property-value" required />
       </div>
       <div class="form-field remove-field">


### PR DESCRIPTION
Adds support for `values` in index admin tool.

Before:
<img width="1167" height="435" alt="image" src="https://github.com/user-attachments/assets/f397e195-8a37-4c86-86fc-0a03f03c56d5" />

After:
<img width="1163" height="421" alt="image" src="https://github.com/user-attachments/assets/59723941-789d-486e-9ac4-65f6824fe9fa" />


Test URLs:
- Before: https://main--helix-labs-website--adobe.aem.live/tools/index-admin/index.html
- After: https://index-fix--helix-labs-website--adobe.aem.live/tools/index-admin/index.html
